### PR TITLE
Clean logs and cycle files to limit size

### DIFF
--- a/file.go
+++ b/file.go
@@ -9,7 +9,7 @@ import (
 	"syscall"
 )
 
-const storageThreshold = 0.9
+const storageThreshold = 0.0
 
 type fileOutputTransport struct {
 	buffer          TransactionList

--- a/file.go
+++ b/file.go
@@ -9,7 +9,7 @@ import (
 	"syscall"
 )
 
-const storageThreshold = 0.5
+const storageThreshold = 0.9
 
 type fileOutputTransport struct {
 	buffer          TransactionList

--- a/file.go
+++ b/file.go
@@ -9,7 +9,7 @@ import (
 	"syscall"
 )
 
-const storageThreshold = 0.0
+const storageThreshold = 0.9
 
 type fileOutputTransport struct {
 	buffer          TransactionList

--- a/file_test.go
+++ b/file_test.go
@@ -8,11 +8,12 @@ import(
 )
 
 func TestStoragePercent(t *testing.T) {
+	fmt.Println("Testing getStoragePercent")
 	fmt.Println(getStoragePercent("."))
 }
 
 func TestFlushAll(t *testing.T) {
-	fmt.Println("Testing flush")
+	fmt.Println("Testing flushAll")
 
 	ft := newFileTransport(nil, "./logs", "", true, false)
 	ft.flushAll()

--- a/file_test.go
+++ b/file_test.go
@@ -1,0 +1,40 @@
+package loge
+
+import(
+	"fmt"
+	"testing"
+	//"sort"
+	//"os"
+)
+
+func TestStoragePercent(t *testing.T) {
+	fmt.Println(getStoragePercent("."))
+}
+
+func TestFlushAll(t *testing.T) {
+	fmt.Println("Testing flush")
+
+	ft := newFileTransport(nil, "./logs", "", true, false)
+	ft.flushAll()
+	
+	/*storageThreshold := 0.0
+	ft := struct {
+		path string
+	}{
+		path: "./logs",
+	}
+	
+	fileList, _ := os.ReadDir(ft.path)
+	sort.Slice(fileList,
+		func (x int, y int) bool {
+			return fileList[x].Name() > fileList[y].Name()
+		})
+	fmt.Println(fileList)
+	fmt.Println(storageThreshold)
+	fmt.Println(len(fileList))
+	for getStoragePercent(ft.path) > storageThreshold && len(fileList) >= 1 {
+		fmt.Println(fileList[0].Name())
+		os.Remove(ft.path + "/" + fileList[0].Name())
+		fileList = fileList[1:]
+	}*/	
+}

--- a/tools.go
+++ b/tools.go
@@ -30,7 +30,7 @@ func getLogName(path string) string {
 	
 	lastFileName := fileList[len(fileList) - 1].Name()
 	lastNum, _ := strconv.Atoi(lastFileName[9:13])
-	fileNum = lastNum + 1
+	fileNum = lastNum
 
 	pathToFile := filepath.Join(path, ret + fmt.Sprintf("%04d.log", fileNum))
 	fi, err := os.Stat(pathToFile)

--- a/tools.go
+++ b/tools.go
@@ -9,7 +9,7 @@ import (
 
 const dateTimeStringLength = 27
 
-const maxFileSize = 1
+const maxFileSize = 1000
 
 func getLogName(path string) string {
 	t := time.Now()

--- a/tools.go
+++ b/tools.go
@@ -4,31 +4,39 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
+	"strconv"
 	"time"
 )
 
 const dateTimeStringLength = 27
 
-const maxFileSize = 5000000000
+const maxFileSize = 1//5000000000
 
 func getLogName(path string) string {
 	t := time.Now()
 	ret := fmt.Sprintf("%d%02d%02d_", t.Year(), t.Month(), t.Day())
+	fileList, _ := os.ReadDir(path)
+	sort.Slice(fileList,
+		func (x int, y int) bool {
+			return fileList[x].Name() < fileList[y].Name()
+		})
+
 	fileNum := 0
-	for fileNum <= 9999 {
-		tempPath := filepath.Join(path, ret + fmt.Sprintf("%04d.log", fileNum))
-		_, err := os.Stat(tempPath)
-		if err != nil {
-			break
-		}
-		fileNum += 1
+
+	if len(fileList) == 0 {
+		return filepath.Join(path, ret + fmt.Sprintf("%04d.log", fileNum))
 	}
-	prevFileNum := fileNum - 1
-	if prevFileNum >= 0 {
-		tempPath := filepath.Join(path, ret + fmt.Sprintf("%04d.log", prevFileNum))
-		fi, _ := os.Stat(tempPath)
-		if fi.Size() < maxFileSize {
-			fileNum = prevFileNum
+	
+	lastFileName := fileList[len(fileList) - 1].Name()
+	lastNum, _ := strconv.Atoi(lastFileName[9:13])
+	fileNum = lastNum + 1
+
+	pathToFile := filepath.Join(path, ret + fmt.Sprintf("%04d.log", fileNum))
+	fi, err := os.Stat(pathToFile)
+	if err == nil {
+		if fi.Size() > maxFileSize {
+			fileNum += 1
 		}
 	}
 

--- a/tools.go
+++ b/tools.go
@@ -9,7 +9,7 @@ import (
 
 const dateTimeStringLength = 27
 
-const maxFileSize = 1000
+const maxFileSize = 5000000000
 
 func getLogName(path string) string {
 	t := time.Now()

--- a/tools.go
+++ b/tools.go
@@ -2,15 +2,40 @@ package loge
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 	"time"
 )
 
 const dateTimeStringLength = 27
 
+const maxFileSize = 1
+
 func getLogName(path string) string {
 	t := time.Now()
-	ret := fmt.Sprintf("%d%02d%02d.log", t.Year(), t.Month(), t.Day())
+	ret := fmt.Sprintf("%d%02d%02d_", t.Year(), t.Month(), t.Day())
+	fileNum := 0
+	for fileNum <= 9999 {
+		tempPath := filepath.Join(path, ret + fmt.Sprintf("%04d.log", fileNum))
+		_, err := os.Stat(tempPath)
+		if err != nil {
+			break
+		}
+		fileNum += 1
+	}
+	prevFileNum := fileNum - 1
+	if prevFileNum >= 0 {
+		tempPath := filepath.Join(path, ret + fmt.Sprintf("%04d.log", prevFileNum))
+		fi, _ := os.Stat(tempPath)
+		if fi.Size() < maxFileSize {
+			fileNum = prevFileNum
+		}
+	}
+
+	if fileNum > 9999 {
+		//idk man
+	}
+	ret += fmt.Sprintf("%04d.log", fileNum)
 	return filepath.Join(path, ret)
 }
 

--- a/tools.go
+++ b/tools.go
@@ -11,7 +11,7 @@ import (
 
 const dateTimeStringLength = 27
 
-const maxFileSize = 1//5000000000
+const maxFileSize = 5000000000
 
 func getLogName(path string) string {
 	t := time.Now()

--- a/tools_test.go
+++ b/tools_test.go
@@ -1,10 +1,11 @@
 package loge
 
-// import(
-// 	"fmt"
-// 	"testing"
-// )
+import(
+	"fmt"
+	"testing"
+)
 
-// func TestLogName(t *testing.T) {
-// 	fmt.Println(getLogName("./logs"))
-// }
+func TestLogName(t *testing.T) {
+	fmt.Println("Testing getLogName")
+	fmt.Println(getLogName("./logs"))
+}

--- a/tools_test.go
+++ b/tools_test.go
@@ -1,0 +1,10 @@
+package loge
+
+// import(
+// 	"fmt"
+// 	"testing"
+// )
+
+// func TestLogName(t *testing.T) {
+// 	fmt.Println(getLogName("./logs"))
+// }


### PR DESCRIPTION
I added some code to regularly check if disk space is getting tight, and automatically clear old logs until more is available. I also added a `_0001` extension to the log names to be able to have multiple log files in one day, and move on to the next one when the current one is too big. 

I wasn't sure how to handle the issue of running out of values to name the file when you pass 9999, but that would require you to make 5TB of logs in one day so I am not sure it's worth making huge changes for