### PR TITLE
Rclapps/clean and cycle

### DIFF
--- a/file.go
+++ b/file.go
@@ -9,7 +9,7 @@ import (
 	"syscall"
 )
 
-const storageThreshold = 0.9
+const storageThreshold = 0.0
 
 type fileOutputTransport struct {
 	buffer          TransactionList

--- a/file.go
+++ b/file.go
@@ -9,7 +9,7 @@ import (
 	"syscall"
 )
 
-const storageThreshold = 0.5
+const storageThreshold = 0.9
 
 type fileOutputTransport struct {
 	buffer          TransactionList

--- a/file.go
+++ b/file.go
@@ -88,8 +88,12 @@ func (ft *fileOutputTransport) flushAll() error {
 		func(x int, y int) bool {
 			f1, err1 := os.Stat(fileList[x].Name())
 			f2, err2 := os.Stat(fileList[y].Name())
-			if err1 != nil || err2 != nil {
+			if err1 != nil && err2 != nil {
 				return false
+			} else if err1 != nil {
+				return false
+			} else if err2 != nil {
+				return true
 			}
 			return f1.ModTime().Before(f2.ModTime())
 		})

--- a/file.go
+++ b/file.go
@@ -9,7 +9,7 @@ import (
 	"syscall"
 )
 
-const storageThreshold = 0.0
+const storageThreshold = 0.9
 
 type fileOutputTransport struct {
 	buffer          TransactionList

--- a/file.go
+++ b/file.go
@@ -79,24 +79,33 @@ func (ft *fileOutputTransport) Stop() {
 	ft.wg.Wait()
 }
 
-func (ft *fileOutputTransport) flushAll() {
+func (ft *fileOutputTransport) flushAll() error {
 	if ft.terminated {
-		return
+		return nil
 	}
 
 	fileList, _ := os.ReadDir(ft.path)
 	sort.Slice(fileList,
-		func (x int, y int) bool {
-			return fileList[x].Name() > fileList[y].Name()
+		func(x int, y int) bool {
+			f1, err1 := os.Stat(fileList[x].Name())
+			f2, err2 := os.Stat(fileList[y].Name())
+			if err1 != nil || err2 != nil {
+				return false
+			}
+			return f1.ModTime().Before(f2.ModTime())
 		})
 	for getStoragePercent(ft.path) > storageThreshold && len(fileList) >= 1 {
 		os.Remove(filepath.Join(ft.path, fileList[0].Name()))
 		fileList = fileList[1:]
 	}
-	
+
 	if ft.file != nil {
 		if ft.rotation {
-			if ft.currentFilename != getLogName(ft.path) {
+			logName, err := getLogName(ft.path)
+			if err != nil {
+				return err
+			}
+			if ft.currentFilename != logName {
 				ft.file.Close()
 				ft.file = nil
 				ft.writer = nil
@@ -109,14 +118,14 @@ func (ft *fileOutputTransport) flushAll() {
 		if ft.file == nil {
 			ft.terminated = true
 			os.Stderr.Write([]byte("Unable to create the output file.  Log file output is disabled.\n"))
-			return
+			return nil
 		}
 	}
 
 	ft.transLocker.Lock()
 	if len(ft.trans) == 0 {
 		ft.transLocker.Unlock()
-		return
+		return nil
 	}
 
 	ids := ft.trans
@@ -143,11 +152,16 @@ func (ft *fileOutputTransport) flushAll() {
 	}
 
 	ft.writer.Flush()
+	return nil
 }
 
-func (ft *fileOutputTransport) createFile() {
+func (ft *fileOutputTransport) createFile() error {
 	if ft.rotation {
-		ft.currentFilename = getLogName(ft.path)
+		logName, err := getLogName(ft.path)
+		if err != nil {
+			return err
+		}
+		ft.currentFilename = logName
 	} else {
 		ft.currentFilename = filepath.Join(ft.path, ft.filename)
 	}
@@ -156,10 +170,11 @@ func (ft *fileOutputTransport) createFile() {
 	ft.file, err = os.OpenFile(ft.currentFilename, os.O_RDWR|os.O_CREATE|os.O_APPEND, 0666)
 	if err != nil {
 		ft.file = nil
-		return
+		return nil
 	}
 
 	ft.writer = bufio.NewWriter(ft.file)
+	return nil
 }
 
 func getStoragePercent(logDir string) float64 {

--- a/file_test.go
+++ b/file_test.go
@@ -1,10 +1,10 @@
 package loge
 
-import(
+import (
 	"fmt"
+	"os"
+	"sort"
 	"testing"
-	//"sort"
-	//"os"
 )
 
 func TestStoragePercent(t *testing.T) {
@@ -17,17 +17,13 @@ func TestFlushAll(t *testing.T) {
 
 	ft := newFileTransport(nil, "./logs", "", true, false)
 	ft.flushAll()
-	
-	/*storageThreshold := 0.0
-	ft := struct {
-		path string
-	}{
-		path: "./logs",
-	}
-	
+
+	storageThreshold := 0.0
+	ft.path = "./logs"
+
 	fileList, _ := os.ReadDir(ft.path)
 	sort.Slice(fileList,
-		func (x int, y int) bool {
+		func(x int, y int) bool {
 			return fileList[x].Name() > fileList[y].Name()
 		})
 	fmt.Println(fileList)
@@ -37,5 +33,5 @@ func TestFlushAll(t *testing.T) {
 		fmt.Println(fileList[0].Name())
 		os.Remove(ft.path + "/" + fileList[0].Name())
 		fileList = fileList[1:]
-	}*/	
+	}
 }

--- a/file_test.go
+++ b/file_test.go
@@ -8,11 +8,12 @@ import(
 )
 
 func TestStoragePercent(t *testing.T) {
+	fmt.Println("Testing getStoragePercent")
 	fmt.Println(getStoragePercent("."))
 }
 
 func TestFlushAll(t *testing.T) {
-	fmt.Println("Testing flush")
+	fmt.Println("Testing flushAll")
 
 	ft := newFileTransport(nil, "./logs", "", true, false)
 	ft.flushAll()

--- a/file_test.go
+++ b/file_test.go
@@ -1,0 +1,40 @@
+package loge
+
+import(
+	"fmt"
+	"testing"
+	//"sort"
+	//"os"
+)
+
+func TestStoragePercent(t *testing.T) {
+	fmt.Println(getStoragePercent("."))
+}
+
+func TestFlushAll(t *testing.T) {
+	fmt.Println("Testing flush")
+
+	ft := newFileTransport(nil, "./logs", "", true, false)
+	ft.flushAll()
+	
+	/*storageThreshold := 0.0
+	ft := struct {
+		path string
+	}{
+		path: "./logs",
+	}
+	
+	fileList, _ := os.ReadDir(ft.path)
+	sort.Slice(fileList,
+		func (x int, y int) bool {
+			return fileList[x].Name() > fileList[y].Name()
+		})
+	fmt.Println(fileList)
+	fmt.Println(storageThreshold)
+	fmt.Println(len(fileList))
+	for getStoragePercent(ft.path) > storageThreshold && len(fileList) >= 1 {
+		fmt.Println(fileList[0].Name())
+		os.Remove(ft.path + "/" + fileList[0].Name())
+		fileList = fileList[1:]
+	}*/	
+}

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,7 @@ module github.com/securecollc/loge
 
 go 1.12
 
-require github.com/potakhov/cache v0.0.1
+require (
+	github.com/potakhov/cache v0.0.1
+	golang.org/x/sys v0.25.0 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,4 @@
 github.com/potakhov/cache v0.0.1 h1:XCHcz7vU0y+dkKGBPGwCHyHGJ1e2ObvhxbLyjV0k0Ww=
 github.com/potakhov/cache v0.0.1/go.mod h1:Kjqv0VQNS3ubA6UNRuB9Zfl/RZUs3xgBVeS01BBVdzs=
+golang.org/x/sys v0.25.0 h1:r+8e+loiHxRqhXVl6ML1nO3l1+oFoWbnlu2Ehimmi34=
+golang.org/x/sys v0.25.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=

--- a/storageReader_darwin.go
+++ b/storageReader_darwin.go
@@ -1,0 +1,18 @@
+package loge
+
+import (
+	"syscall"
+)
+
+func getStoragePercent(logDir string) float64 {
+	var fileSystemStats syscall.Statfs_t
+	if err := syscall.Statfs(logDir, &fileSystemStats); err != nil {
+		return -1
+	}
+
+	totalBytes := float64(fileSystemStats.Blocks * uint64(fileSystemStats.Bsize))
+	usedBytes := float64((fileSystemStats.Blocks - fileSystemStats.Bavail) * uint64(fileSystemStats.Bsize))
+
+	percentUsage := (usedBytes / totalBytes)
+	return percentUsage
+}

--- a/storageReader_darwin.go
+++ b/storageReader_darwin.go
@@ -1,18 +1,1 @@
-package loge
-
-import (
-	"syscall"
-)
-
-func getStoragePercent(logDir string) float64 {
-	var fileSystemStats syscall.Statfs_t
-	if err := syscall.Statfs(logDir, &fileSystemStats); err != nil {
-		return -1
-	}
-
-	totalBytes := float64(fileSystemStats.Blocks * uint64(fileSystemStats.Bsize))
-	usedBytes := float64((fileSystemStats.Blocks - fileSystemStats.Bavail) * uint64(fileSystemStats.Bsize))
-
-	percentUsage := (usedBytes / totalBytes)
-	return percentUsage
-}
+storageReader_linux.go

--- a/storageReader_linux.go
+++ b/storageReader_linux.go
@@ -1,0 +1,18 @@
+package loge
+
+import (
+	"syscall"
+)
+
+func getStoragePercent(logDir string) float64 {
+	var fileSystemStats syscall.Statfs_t
+	if err := syscall.Statfs(logDir, &fileSystemStats); err != nil {
+		return -1
+	}
+
+	totalBytes := float64(fileSystemStats.Blocks * uint64(fileSystemStats.Bsize))
+	usedBytes := float64((fileSystemStats.Blocks - fileSystemStats.Bavail) * uint64(fileSystemStats.Bsize))
+
+	percentUsage := (usedBytes / totalBytes)
+	return percentUsage
+}

--- a/storageReader_windows.go
+++ b/storageReader_windows.go
@@ -1,0 +1,21 @@
+package loge
+
+import (
+	"golang.org/x/sys/windows"
+)
+
+func getStoragePercent(logDir string) float64 {
+	var freeBytesAvailable uint64
+	var totalNumberOfBytes uint64
+	var totalNumberOfFreeBytes uint64
+
+	err := windows.GetDiskFreeSpaceEx(windows.StringToUTF16Ptr("."),
+		&freeBytesAvailable, &totalNumberOfBytes, &totalNumberOfFreeBytes)
+	if err != nil {
+		return -1
+	}
+
+	// Returns a float64 between 0 and 1 representing the percent of disk space taken up
+	var percentUsage float64 = 1 - (float64(freeBytesAvailable) / float64(totalNumberOfBytes))
+	return percentUsage
+}

--- a/tools.go
+++ b/tools.go
@@ -30,7 +30,7 @@ func getLogName(path string) string {
 	
 	lastFileName := fileList[len(fileList) - 1].Name()
 	lastNum, _ := strconv.Atoi(lastFileName[9:13])
-	fileNum = lastNum + 1
+	fileNum = lastNum
 
 	pathToFile := filepath.Join(path, ret + fmt.Sprintf("%04d.log", fileNum))
 	fi, err := os.Stat(pathToFile)

--- a/tools.go
+++ b/tools.go
@@ -9,7 +9,7 @@ import (
 
 const dateTimeStringLength = 27
 
-const maxFileSize = 1
+const maxFileSize = 1000
 
 func getLogName(path string) string {
 	t := time.Now()

--- a/tools.go
+++ b/tools.go
@@ -4,31 +4,39 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
+	"strconv"
 	"time"
 )
 
 const dateTimeStringLength = 27
 
-const maxFileSize = 5000000000
+const maxFileSize = 1//5000000000
 
 func getLogName(path string) string {
 	t := time.Now()
 	ret := fmt.Sprintf("%d%02d%02d_", t.Year(), t.Month(), t.Day())
+	fileList, _ := os.ReadDir(path)
+	sort.Slice(fileList,
+		func (x int, y int) bool {
+			return fileList[x].Name() < fileList[y].Name()
+		})
+
 	fileNum := 0
-	for fileNum <= 9999 {
-		tempPath := filepath.Join(path, ret + fmt.Sprintf("%04d.log", fileNum))
-		_, err := os.Stat(tempPath)
-		if err != nil {
-			break
-		}
-		fileNum += 1
+
+	if len(fileList) == 0 {
+		return filepath.Join(path, ret + fmt.Sprintf("%04d.log", fileNum))
 	}
-	prevFileNum := fileNum - 1
-	if prevFileNum >= 0 {
-		tempPath := filepath.Join(path, ret + fmt.Sprintf("%04d.log", prevFileNum))
-		fi, _ := os.Stat(tempPath)
-		if fi.Size() < maxFileSize {
-			fileNum = prevFileNum
+	
+	lastFileName := fileList[len(fileList) - 1].Name()
+	lastNum, _ := strconv.Atoi(lastFileName[9:13])
+	fileNum = lastNum + 1
+
+	pathToFile := filepath.Join(path, ret + fmt.Sprintf("%04d.log", fileNum))
+	fi, err := os.Stat(pathToFile)
+	if err == nil {
+		if fi.Size() > maxFileSize {
+			fileNum += 1
 		}
 	}
 

--- a/tools.go
+++ b/tools.go
@@ -11,7 +11,7 @@ import (
 
 const dateTimeStringLength = 27
 
-const maxFileSize = 5000000000
+const maxFileSize = 10 * 1024 * 1024
 
 func getLogName(path string) string {
 	t := time.Now()

--- a/tools.go
+++ b/tools.go
@@ -9,7 +9,7 @@ import (
 
 const dateTimeStringLength = 27
 
-const maxFileSize = 1000
+const maxFileSize = 5000000000
 
 func getLogName(path string) string {
 	t := time.Now()

--- a/tools.go
+++ b/tools.go
@@ -2,15 +2,40 @@ package loge
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 	"time"
 )
 
 const dateTimeStringLength = 27
 
+const maxFileSize = 1
+
 func getLogName(path string) string {
 	t := time.Now()
-	ret := fmt.Sprintf("%d%02d%02d.log", t.Year(), t.Month(), t.Day())
+	ret := fmt.Sprintf("%d%02d%02d_", t.Year(), t.Month(), t.Day())
+	fileNum := 0
+	for fileNum <= 9999 {
+		tempPath := filepath.Join(path, ret + fmt.Sprintf("%04d.log", fileNum))
+		_, err := os.Stat(tempPath)
+		if err != nil {
+			break
+		}
+		fileNum += 1
+	}
+	prevFileNum := fileNum - 1
+	if prevFileNum >= 0 {
+		tempPath := filepath.Join(path, ret + fmt.Sprintf("%04d.log", prevFileNum))
+		fi, _ := os.Stat(tempPath)
+		if fi.Size() < maxFileSize {
+			fileNum = prevFileNum
+		}
+	}
+
+	if fileNum > 9999 {
+		//idk man
+	}
+	ret += fmt.Sprintf("%04d.log", fileNum)
 	return filepath.Join(path, ret)
 }
 

--- a/tools.go
+++ b/tools.go
@@ -11,7 +11,7 @@ import (
 
 const dateTimeStringLength = 27
 
-const maxFileSize = 1//5000000000
+const maxFileSize = 5000000000
 
 func getLogName(path string) string {
 	t := time.Now()

--- a/tools_test.go
+++ b/tools_test.go
@@ -1,6 +1,6 @@
 package loge
 
-import(
+import (
 	"fmt"
 	"testing"
 )

--- a/tools_test.go
+++ b/tools_test.go
@@ -1,10 +1,11 @@
 package loge
 
-// import(
-// 	"fmt"
-// 	"testing"
-// )
+import(
+	"fmt"
+	"testing"
+)
 
-// func TestLogName(t *testing.T) {
-// 	fmt.Println(getLogName("./logs"))
-// }
+func TestLogName(t *testing.T) {
+	fmt.Println("Testing getLogName")
+	fmt.Println(getLogName("./logs"))
+}

--- a/tools_test.go
+++ b/tools_test.go
@@ -1,0 +1,10 @@
+package loge
+
+// import(
+// 	"fmt"
+// 	"testing"
+// )
+
+// func TestLogName(t *testing.T) {
+// 	fmt.Println(getLogName("./logs"))
+// }


### PR DESCRIPTION
Adds the ability to cycle to new log files when old ones exceed a certain file size. Also deletes old log files when disk is running out of free space. Compiles for linux, windows, and darwin. Tested to work on linux, will follow up after testing on a windows machine. Can't currently test on macOS but it shouldn't be an issue either